### PR TITLE
add record_min_ms option

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1459,6 +1459,10 @@ ___TEMPLATE_PARAMETERS___
                 "displayValue": "record_max_ms"
               },
               {
+                "value": "record_min_ms",
+                "displayValue": "record_min_ms"
+              },
+              {
                 "value": "record_sessions_percent",
                 "displayValue": "record_sessions_percent"
               },


### PR DESCRIPTION
@chiyc customer noticed we were missing the `record_min_ms` option in GTM template

https://docs.mixpanel.com/docs/tracking-methods/sdks/javascript#init-options

this change ensures it appears in dropdowns

https://mixpanel.slack.com/archives/C05PTEK8NQZ/p1726542696148429