### PR TITLE
Add autocapture mode as tag option

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://mixpanel.com/"
 documentation: "https://developer.mixpanel.com/docs/javascript-quickstart"
 versions:
+  - sha: 9c34946764017e0618d178a60ddc9f9122a9fe54
+    changeNotes: Add autocapture config option
   - sha: 1feb80cd2a71f6a12041aacb2785e81c03840fbe
     changeNotes: Add record_min_ms config option for session recording.
   - sha: 5ae3c7cc756a78ef1dc1d04ed31c18a274399214

--- a/template.tpl
+++ b/template.tpl
@@ -1496,6 +1496,31 @@ ___TEMPLATE_PARAMETERS___
         "help": "For each option, click the \u003cstrong\u003eAdd option\u003c/strong\u003e button. Select the option name from the drop-down list, and set the value to whatever you want the option to be. Boolean values (e.g. \u003cstrong\u003etrue\u003c/strong\u003e and \u003cstrong\u003efalse\u003c/strong\u003e) are automatically converted from strings to Booleans by the template code. Similarly, number values (e.g. \u003cstrong\u003e365\u003c/strong\u003e) are automatically converted to numbers by the template code. Functions, objects, and other non-string types need to be passed using a GTM variable, selected from the list."
       }
     ]
+  },
+  {
+    "type": "GROUP",
+    "name": "autocaptureGroup",
+    "displayName": "Autocapture",
+    "groupStyle": "ZIPPY_CLOSED",
+    "subParams": [
+      {
+        "type": "SELECT",
+        "name": "autocaptureMode",
+        "displayName": "Autocapture Mode",
+        "macrosInSelect": true,
+        "selectItems": [
+          {
+            "value": false,
+            "displayValue": "Disabled"
+          },
+          {
+            "value": true,
+            "displayValue": "Enabled"
+          }
+        ],
+        "simpleValueType": true
+      }
+    ]
   }
 ]
 
@@ -1565,6 +1590,7 @@ const libraryName = data.instanceName ? data.instanceName + '.' : '';
 const manualOptions = normalizeTable(data.initManualOptions, 'key', 'value') || {};
 
 const initOptions = (data.initOptions === 'manual' ? manualOptions : data.initOptions) || {};
+initOptions.autocapture = data.autocaptureMode;
 if (!initOptions.mp_loader) {
   initOptions.mp_loader = 'gtm';
 }


### PR DESCRIPTION
# Description
This change allows users to easily enable the default autocapture configuration for the SDK. We can follow up with customization as needed.

Users should be able to use container variables to assign an object to the autocapture config if desired.

<img width="1022" alt="Screenshot 2025-02-04 at 1 01 25 PM" src="https://github.com/user-attachments/assets/b7a17745-2b8b-4c67-b9f9-bb84418d1376" />