### PR TITLE
Integrate analytics_storage consent with Mixpanel initialization (off by default)

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1602,9 +1602,10 @@ const GTM_DEFAULTS = {
   persistence: 'localStorage',
   stop_utm_persistence: true,
 };
+
 if (data.optOutTrackingUntilConsentGranted) {
-  log(LOG_PREFIX, "Defaulting opt_out_tracking_by_default to true");
-  GTM_DEFAULTS.opt_out_tracking_by_default = true;
+  // Don't set opt_out_tracking_by_default, since that unconditionally deletes the user, which
+  // we don't want to do while figuring out GTM consent.
 }
 
 for (const option in GTM_DEFAULTS) {
@@ -1620,10 +1621,12 @@ const applyOptOutTrackingUntilConsentGranted = () => {
   const applyOptInOutChange = (consentGranted) => {
     const desiredOptInOutCommand = consentGranted ? 'opt_in_tracking' : 'opt_out_tracking';
     log(LOG_PREFIX, "Applying opt in/out command: " + desiredOptInOutCommand);
-    // By default, Mixpanel will emit opt-in / opt-out events every
-    // time this is called. Disable that, since this is not a user action.
-    const noOpTrackFunction = () => {};
-    callMixpanel(desiredOptInOutCommand, {track: noOpTrackFunction});
+    // By default, Mixpanel will emit opt-in events every time this is called. Disable that,
+    // since this is not a user action.
+    //
+    // Also, whenever calling opt_out_tracking(), Mixpanel will by default delete the user and
+    // clear the persistence store. Disable that as well.
+    callMixpanel(desiredOptInOutCommand, {track: false, delete_user: false, clear_persistence: false});
   };
 
   // Apply the current analytics_storage consent setting in case it changed since mixpanel.init()


### PR DESCRIPTION
This adds a new GTM template option `init.optOutTrackingUntilConsentGranted` (off by default, but we should probably change this to on by default and make an announcement) to Mixpanel initialization to integrate with Google Tag Manager `analytics_storage` consent.

This requires the user have already integrated Google Tag Manager with a Consent Mode Provider:

https://support.google.com/tagmanager/answer/10718549?hl=en#cmp-integrations

If enabled, this will set `opt_out_tracking_by_default` to `true` in the Mixpanel init options. It will then read
if the user has granted `analytics_storage` consent and will monitor changes to `analytics_storage` consent, opting the 
user in or out of tracking as that changes at runtime.

This can't use `disablePersistence` because of https://github.com/mixpanel/mixpanel-js/issues/541 (session recording doesn't re-enable itself when persistence is enabled).

Fixes #22 .