### PR TITLE
MULTI-161 normalize whitespace and convert to undefined for SR selectors

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://mixpanel.com/"
 documentation: "https://developer.mixpanel.com/docs/javascript-quickstart"
 versions:
+  - sha: TODO
+    changeNotes: Fix Session Replay privacy selectors (record_mask_text_selector, record_block_selector) breaking when set to empty or whitespace values in "Set options manually"; these now fall back to the SDK default instead of producing an invalid CSS selector.
   - sha: f1f41ff8d8093fc8b9ad04800d7c2273d82605e6
     changeNotes: Add remote_settings_mode config option for controlling how remote settings are fetched during initialization (strict, fallback, or disabled).
   - sha: d35886729da49e7f86acd2da506173b2bd743066

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 homepage: "https://mixpanel.com/"
 documentation: "https://developer.mixpanel.com/docs/javascript-quickstart"
 versions:
-  - sha: TODO
+  - sha: d79da91f28d774b1621c46dc9137f1e853219ac3
     changeNotes: Fix Session Replay privacy selectors (record_mask_text_selector, record_block_selector) breaking when set to empty or whitespace values in "Set options manually"; these now fall back to the SDK default instead of producing an invalid CSS selector.
   - sha: f1f41ff8d8093fc8b9ad04800d7c2273d82605e6
     changeNotes: Add remote_settings_mode config option for controlling how remote settings are fetched during initialization (strict, fallback, or disabled).

--- a/template.tpl
+++ b/template.tpl
@@ -1594,13 +1594,20 @@ const normalize = val => {
   return makeNumber(val) || val;
 };
 
+const SELECTOR_OPTIONS = ['record_block_selector', 'record_mask_text_selector'];
+
 // Normalize the template table
 const normalizeTable = (table, prop, val) => {
   if (table && table.length) {
     table = table.map(row => {
       const obj = {};
       obj[prop] = row[prop];
-      obj[val] = normalize(row[val]);
+      let value = normalize(row[val]);
+      if (SELECTOR_OPTIONS.indexOf(row[prop]) !== -1 &&
+          getType(value) === 'string' && value.trim() === '') {
+        value = undefined;
+      }
+      obj[val] = value;
       return obj;
     });
     return makeTableMap(table, prop, val);


### PR DESCRIPTION
## Summary

Per the [Session Replay privacy docs](https://docs.mixpanel.com/docs/session-replay/session-replay-privacy-controls), the correct value when a selector isn't meaningfully set is `undefined` ("Pass `undefined` to use the SDK default, or omit the key entirely"). The template never performed that coercion — which is why the documented workaround requires a Custom JavaScript variable.

This makes the "Set options manually" path behave like the documented Custom-JavaScript-variable workaround, so that workaround is no longer needed.

Fixes [MULTI-161](https://linear.app/mixpanel/issue/MULTI-161).
